### PR TITLE
Explicit defhydra autoload

### DIFF
--- a/vunit-mode.el
+++ b/vunit-mode.el
@@ -408,7 +408,7 @@ If none were selected start new selection."
   (when (derived-mode-p 'vhdl-mode)
     (vunit-mode 1)))
 
-;;;###autoload
+;;;###autoload(autoload 'vunit-buffer-menu/body "vunit-mode")
 (defhydra vunit-buffer-menu
   (:color blue
           :pre (vunit--flag-enabled-message))


### PR DESCRIPTION
I’m trying to package `emacs-vunit-mode` for [Guix](https://codeberg.org/guix/guix/pulls/1073).

Currently, the generated `autoloads` file cannot compile, and errors, as you may see [here](https://codeberg.org/guix/guix/pulls/1073#issuecomment-5749295).

	...
	Compiling ‘vunit-mode-autoloads.el’
	...
	Error: void-variable (vunit-buffer-menu)

This happens only when one attempts to compile the `autoloads` before the `vunit-mode.el` file itself: the other way round compiles as expected.

This may be fixed by using

	;;;###autoload(autoload 'vunit-buffer-menu/body "vunit-mode")

instead of the default autoload calling.